### PR TITLE
Allow wss connections

### DIFF
--- a/src/turbo_flask/turbo.py
+++ b/src/turbo_flask/turbo.py
@@ -71,7 +71,11 @@ class Turbo:
         if ws_route:
             return Markup(f'''<script type="module">
 import * as Turbo from "{url}";
-Turbo.connectStreamSource(new WebSocket(`ws://${{location.host}}{ws_route}`));
+try {
+    Turbo.connectStreamSource(new WebSocket(`ws://${location.host}/turbo-stream`));
+} catch(error) {
+    Turbo.connectStreamSource(new WebSocket(`wss://${location.host}/turbo-stream`));
+}
 </script>''')
         else:
             return Markup(f'<script type="module" src="{url}"></script>')


### PR DESCRIPTION
ws:// is only allowed if the webpage is served over HTTP. If serving the webpage over HTTPS then a wss:// URL must be sent to the browser.
To do this we attempt to load the ws:// URL first and if the browser throws a DOMexception then we "catch" it and attempts to setup a wss:// URL instead.