### PR TITLE
Add after and before streams

### DIFF
--- a/src/turbo_flask/turbo.py
+++ b/src/turbo_flask/turbo.py
@@ -6,7 +6,7 @@ from markupsafe import Markup
 
 _CDN = 'https://cdn.skypack.dev'
 _PKG = '@hotwired/turbo'
-_VER = 'v7.0.0-rc.4-2gog3kUWZSvvlnfgDD3l'
+_VER = 'v7.0.1-Ugtf0P5kipzmpINBLqbM'
 
 
 class Turbo:

--- a/src/turbo_flask/turbo.py
+++ b/src/turbo_flask/turbo.py
@@ -150,6 +150,22 @@ Turbo.connectStreamSource(new WebSocket(`ws${{location.protocol.substring(4)}}//
         """
         return self._make_stream('remove', '', target)
 
+    def after(self, content, target):
+        """Create an after stream.
+
+        :param content: the HTML content to include in the stream.
+        :param target: the target ID for this change.
+        """
+        return self._make_stream('after', content, target)
+
+    def before(self, content, target):
+        """Create an before stream.
+
+        :param content: the HTML content to include in the stream.
+        :param target: the target ID for this change.
+        """
+        return self._make_stream('before', content, target)
+
     def stream(self, stream):
         """Create a turbo stream response.
 

--- a/tests/test_turbo.py
+++ b/tests/test_turbo.py
@@ -139,7 +139,7 @@ class TestTurbo(unittest.TestCase):
         app = Flask(__name__)
         turbo = turbo_flask.Turbo(app)
 
-        actions = ['append', 'prepend', 'replace', 'update']
+        actions = ['append', 'prepend', 'replace', 'update', 'after', 'before']
         for action in actions:
             assert getattr(turbo, action)('foo', 'bar') == (
                 f'<turbo-stream action="{action}" target="bar">'


### PR DESCRIPTION
Adding actions for `after` and `before` streams, added in v7.0.0

It seems like it works on v7.0.0-rc4, but it would be nice to include an update to v7.0.1 in this PR as well. I'm unsure how to do that. Will be glad for help on that.

I also guess there should be some test added for this?

- [x] add after and before
- [x] update to v7.0.1
- [x] add tests?