### PR TITLE
Feature/target multiple elements

### DIFF
--- a/src/turbo_flask/turbo.py
+++ b/src/turbo_flask/turbo.py
@@ -110,7 +110,12 @@ class Turbo:
         return to in self.clients
 
     def _make_stream(self, action, content, target):
-        return (f'<turbo-stream action="{action}" target="{target}">'
+        starget = str(target)
+        if starget.startswith("."):
+            turbo_target = f'targets="{target}"'
+        else:
+            turbo_target = f'target="{target}"'
+        return (f'<turbo-stream action="{action}" {turbo_target}>'
                 f'<template>{content}</template></turbo-stream>')
 
     def append(self, content, target):

--- a/src/turbo_flask/turbo.py
+++ b/src/turbo_flask/turbo.py
@@ -109,69 +109,72 @@ class Turbo:
             return self.clients != {}
         return to in self.clients
 
-    def _make_stream(self, action, content, target):
-        starget = str(target)
-        if starget.startswith("."):
-            turbo_target = f'targets="{target}"'
-        else:
-            turbo_target = f'target="{target}"'
-        return (f'<turbo-stream action="{action}" {turbo_target}>'
+    def _make_stream(self, action, content, target, multiple):
+        return (f'<turbo-stream action="{action}" '
+                f'{"targets" if multiple else "target"}="{target}">'
                 f'<template>{content}</template></turbo-stream>')
 
-    def append(self, content, target):
+    def append(self, content, target, multiple=False):
         """Create an append stream.
 
         :param content: the HTML content to include in the stream.
         :param target: the target ID or CSS query selector for this change.
+        :param multiple: set to True if target is a CSS query selector.
         """
-        return self._make_stream('append', content, target)
+        return self._make_stream('append', content, target, multiple)
 
-    def prepend(self, content, target):
+    def prepend(self, content, target, multiple=False):
         """Create a prepend stream.
 
         :param content: the HTML content to include in the stream.
         :param target: the target ID or CSS query selector for this change.
+        :param multiple: set to True if target is a CSS query selector.
         """
-        return self._make_stream('prepend', content, target)
+        return self._make_stream('prepend', content, target, multiple)
 
-    def replace(self, content, target):
+    def replace(self, content, target, multiple=False):
         """Create a replace stream.
 
         :param content: the HTML content to include in the stream.
         :param target: the target ID or CSS query selector for this change.
+        :param multiple: set to True if target is a CSS query selector.
         """
-        return self._make_stream('replace', content, target)
+        return self._make_stream('replace', content, target, multiple)
 
-    def update(self, content, target):
+    def update(self, content, target, multiple=False):
         """Create an update stream.
 
         :param content: the HTML content to include in the stream.
         :param target: the target ID or CSS query selector for this change.
+        :param multiple: set to True if target is a CSS query selector.
         """
-        return self._make_stream('update', content, target)
+        return self._make_stream('update', content, target, multiple)
 
-    def remove(self, target):
+    def remove(self, target, multiple=False):
         """Create a remove stream.
 
         :param target: the target ID or CSS query selector for this change.
+        :param multiple: set to True if target is a CSS query selector.
         """
-        return self._make_stream('remove', '', target)
+        return self._make_stream('remove', '', target, multiple)
 
-    def after(self, content, target):
+    def after(self, content, target, multiple=False):
         """Create an after stream.
 
         :param content: the HTML content to include in the stream.
         :param target: the target ID or CSS query selector for this change.
+        :param multiple: set to True if target is a CSS query selector.
         """
-        return self._make_stream('after', content, target)
+        return self._make_stream('after', content, target, multiple)
 
-    def before(self, content, target):
+    def before(self, content, target, multiple=False):
         """Create an before stream.
 
         :param content: the HTML content to include in the stream.
         :param target: the target ID or CSS query selector for this change.
+        :param multiple: set to True if target is a CSS query selector.
         """
-        return self._make_stream('before', content, target)
+        return self._make_stream('before', content, target, multiple)
 
     def stream(self, stream):
         """Create a turbo stream response.

--- a/src/turbo_flask/turbo.py
+++ b/src/turbo_flask/turbo.py
@@ -122,7 +122,7 @@ class Turbo:
         """Create an append stream.
 
         :param content: the HTML content to include in the stream.
-        :param target: the target ID for this change.
+        :param target: the target ID or CSS query selector for this change.
         """
         return self._make_stream('append', content, target)
 
@@ -130,7 +130,7 @@ class Turbo:
         """Create a prepend stream.
 
         :param content: the HTML content to include in the stream.
-        :param target: the target ID for this change.
+        :param target: the target ID or CSS query selector for this change.
         """
         return self._make_stream('prepend', content, target)
 
@@ -138,7 +138,7 @@ class Turbo:
         """Create a replace stream.
 
         :param content: the HTML content to include in the stream.
-        :param target: the target ID for this change.
+        :param target: the target ID or CSS query selector for this change.
         """
         return self._make_stream('replace', content, target)
 
@@ -146,14 +146,14 @@ class Turbo:
         """Create an update stream.
 
         :param content: the HTML content to include in the stream.
-        :param target: the target ID for this change.
+        :param target: the target ID or CSS query selector for this change.
         """
         return self._make_stream('update', content, target)
 
     def remove(self, target):
         """Create a remove stream.
 
-        :param target: the target ID for this change.
+        :param target: the target ID or CSS query selector for this change.
         """
         return self._make_stream('remove', '', target)
 
@@ -161,7 +161,7 @@ class Turbo:
         """Create an after stream.
 
         :param content: the HTML content to include in the stream.
-        :param target: the target ID for this change.
+        :param target: the target ID or CSS query selector for this change.
         """
         return self._make_stream('after', content, target)
 
@@ -169,7 +169,7 @@ class Turbo:
         """Create an before stream.
 
         :param content: the HTML content to include in the stream.
-        :param target: the target ID for this change.
+        :param target: the target ID or CSS query selector for this change.
         """
         return self._make_stream('before', content, target)
 

--- a/tests/test_turbo.py
+++ b/tests/test_turbo.py
@@ -222,15 +222,15 @@ class TestTurbo(unittest.TestCase):
         turbo.clients['456'][0].send.assert_not_called()
 
     def test_make_stream(self):
-        params_list = [("target", "bar"), ("targets", ".bars")]
+        params_list = [("target", "bar", False), ("targets", ".bars", True)]
         app = Flask(__name__)
         turbo = turbo_flask.Turbo(app)
-        for target, name in params_list:
-            with self.subTest(target=target, name=name):
+        for target, name, multiple in params_list:
+            with self.subTest(target=target, name=name, multiple=multiple):
                 expected = (
                     f'<turbo-stream action="foo" {target}="{name}">'
                     '<template>baz</template>'
                     '</turbo-stream>'
                 )
-                got = turbo._make_stream("foo", "baz", name)
+                got = turbo._make_stream("foo", "baz", name, multiple)
                 self.assertEqual(expected, got)

--- a/tests/test_turbo.py
+++ b/tests/test_turbo.py
@@ -220,3 +220,17 @@ class TestTurbo(unittest.TestCase):
                    to=['123'])
         turbo.clients['123'][0].send.assert_called_with(expected_stream)
         turbo.clients['456'][0].send.assert_not_called()
+
+    def test_make_stream(self):
+        params_list = [("target", "bar"), ("targets", ".bars")]
+        app = Flask(__name__)
+        turbo = turbo_flask.Turbo(app)
+        for target, name in params_list:
+            with self.subTest(target=target, name=name):
+                expected = (
+                    f'<turbo-stream action="foo" {target}="{name}">'
+                    '<template>baz</template>'
+                    '</turbo-stream>'
+                )
+                got = turbo._make_stream("foo", "baz", name)
+                self.assertEqual(expected, got)


### PR DESCRIPTION
Hi @miguelgrinberg 

Great library, thanks for creating/maintaining it!

We're embedding some "live" solar generation data in our [Big Solar Coop](https://bigsolar.coop/ ) site however are running into limitations with a Wordpress theme duplicating div IDs to enable responsive views. We would like to be able to stream to multiple divs based on CSS class names as per  https://turbo.hotwired.dev/reference/streams#targeting-multiple-elements (rather than pushing to different divs e.g. mobile-div, desktop-div).

See suggested change to handle streaming updates to multiple elements using a CSS query selector as the target rather than just the div ID.

Am I being to simplistic with the switching logic?

Thanks!